### PR TITLE
Fix bug of emtpy identity score list

### DIFF
--- a/ConsensusModule.pyx
+++ b/ConsensusModule.pyx
@@ -72,7 +72,7 @@ def OptimizeReps(Sequence, Qscores, repLength):
 
   identityScores = []
   i = 0
-  while i < len(Sequence) - repLength * 3:
+  while i <= len(Sequence) - repLength * 3:
     identity = 0
     rep1 = Sequence[i:i+repLength]
     rep2 = Sequence[i+repLength:i+repLength*2]


### PR DESCRIPTION
When Sequence length is exactly 3 times of repeat length, the identity score list will be empty.